### PR TITLE
Empty {#ADVSNMPINDEX1}

### DIFF
--- a/advsnmp.discovery/advsnmp.discovery
+++ b/advsnmp.discovery/advsnmp.discovery
@@ -150,6 +150,7 @@ print "\t\"data\":[\n";
 my $first_line = 1; 
 #for (my $i = 0; $i < $#INDEXES; $i++) {
 foreach my $line_index (sort keys %INDEXES) {
+    $line_index=~ s/^;//;
 
     # print if it is not the first line
     if($first_line) {


### PR DESCRIPTION
I'm trying to get list of Cisco's E1 interfaces, it's formatted as .1.3.6.1.4.1.9.10.19.1.1.9.1.3.slot.port, so 4-port card in slot 6 looks like:

> $ snmpwalk  -c Asoramog -v2c  10.32.3.40 .1.3.6.1.4.1.9.10.19.1.1.9.1.3
> SNMPv2-SMI::enterprises.9.10.19.1.1.9.1.3.6.0 = Gauge32: 19
> SNMPv2-SMI::enterprises.9.10.19.1.1.9.1.3.6.1 = Gauge32: 20
> SNMPv2-SMI::enterprises.9.10.19.1.1.9.1.3.6.2 = Gauge32: 12
> SNMPv2-SMI::enterprises.9.10.19.1.1.9.1.3.6.3 = Gauge32: 27

but advsnmp.discovery output looks like

> $ /usr/local/share/zabbix/externalscripts/advsnmp.discovery "10.32.3.40" "-v2c -cAsoramog" ".1.3.6.1.4.1.9.10.19.1.1.9.1.3" "1.2" 
> {
>   "data":[
>       {
>       "{#ADVSNMPINDEX1}": "",
>       "{#ADVSNMPINDEX2}": "6.0",
>       "{#ADVSNMPVALUE}":"20"
>       }   ,
>       {
>       "{#ADVSNMPINDEX1}": "",
>       "{#ADVSNMPINDEX2}": "6.1",
>       "{#ADVSNMPVALUE}":"21"
>       }   ,
>       {
>       "{#ADVSNMPINDEX1}": "",
>       "{#ADVSNMPINDEX2}": "6.2",
>       "{#ADVSNMPVALUE}":"21"
>       }   ,
>            …

because $line_index in `foreach my $line_index (sort keys %INDEXES)` block looks like ";6.0", ";6.1", ";6.2", ";6.3" (tested on CentOS 5.8 [net-snmp-5.3.2.2-17.el5_8.1] and FreeBSD 8.2 [net-snmp-5.7.1]) and `( split(/;/, $line_index)` creates two indexes, first is empty.
I don't know if it is a correct solution, but I deal with it by removing ";" at the beginning of the $line_index, please review and commit.
