### PR TITLE
Bugfix: Index will always defined, instead we need to check empty string

### DIFF
--- a/advsnmp.discovery/advsnmp.discovery
+++ b/advsnmp.discovery/advsnmp.discovery
@@ -165,7 +165,7 @@ foreach my $line_index (sort keys %INDEXES) {
     # print all INDEXES
     my $ctr = 1;
     foreach my $index ( split(/;/, $line_index) ) {
-      next if (!defined($index));
+      next if ($index eq '');
       print "\t\t\"{#ADVSNMPINDEX$ctr}\": \"$index\",\n";
       $ctr++
     }


### PR DESCRIPTION
Its a fix for issue with extra INDEX. For example:

```
/usr/bin/snmpwalk -OQn -v2c -c public 192.168.0.2 .1.3.6.1.2.1.2.2.1.2
.1.3.6.1.2.1.2.2.1.2.1 = Vlan1
.1.3.6.1.2.1.2.2.1.2.7 = Vlan7
.1.3.6.1.2.1.2.2.1.2.5023 = Port-channel23
.1.3.6.1.2.1.2.2.1.2.10101 = GigabitEthernet0/1
.1.3.6.1.2.1.2.2.1.2.10102 = GigabitEthernet0/2
.1.3.6.1.2.1.2.2.1.2.10103 = GigabitEthernet0/3
.1.3.6.1.2.1.2.2.1.2.10104 = GigabitEthernet0/4
.1.3.6.1.2.1.2.2.1.2.10105 = GigabitEthernet0/5
.1.3.6.1.2.1.2.2.1.2.10106 = GigabitEthernet0/6
.1.3.6.1.2.1.2.2.1.2.10107 = GigabitEthernet0/7
.1.3.6.1.2.1.2.2.1.2.10108 = GigabitEthernet0/8
.1.3.6.1.2.1.2.2.1.2.10109 = GigabitEthernet0/9
.1.3.6.1.2.1.2.2.1.2.10110 = GigabitEthernet0/10
.1.3.6.1.2.1.2.2.1.2.10111 = GigabitEthernet0/11
.1.3.6.1.2.1.2.2.1.2.10112 = GigabitEthernet0/12
.1.3.6.1.2.1.2.2.1.2.10113 = GigabitEthernet0/13
.1.3.6.1.2.1.2.2.1.2.10114 = GigabitEthernet0/14
.1.3.6.1.2.1.2.2.1.2.10115 = GigabitEthernet0/15
.1.3.6.1.2.1.2.2.1.2.10116 = GigabitEthernet0/16
.1.3.6.1.2.1.2.2.1.2.10117 = GigabitEthernet0/17
.1.3.6.1.2.1.2.2.1.2.10118 = GigabitEthernet0/18
.1.3.6.1.2.1.2.2.1.2.10119 = GigabitEthernet0/19
.1.3.6.1.2.1.2.2.1.2.10120 = GigabitEthernet0/20
.1.3.6.1.2.1.2.2.1.2.10121 = GigabitEthernet0/21
.1.3.6.1.2.1.2.2.1.2.10122 = GigabitEthernet0/22
.1.3.6.1.2.1.2.2.1.2.10123 = GigabitEthernet0/23
.1.3.6.1.2.1.2.2.1.2.10124 = GigabitEthernet0/24
.1.3.6.1.2.1.2.2.1.2.10125 = GigabitEthernet0/25
.1.3.6.1.2.1.2.2.1.2.10126 = GigabitEthernet0/26
.1.3.6.1.2.1.2.2.1.2.10127 = GigabitEthernet0/27
.1.3.6.1.2.1.2.2.1.2.10128 = GigabitEthernet0/28
.1.3.6.1.2.1.2.2.1.2.10501 = Null0

# ./advsnmp.discovery.orig 192.168.0.2 "-v2c -c public" .1.3.6.1.2.1.2.2.1.2 1.1
{
        "data":[
                {
                "{#ADVSNMPINDEX1}": "",
                "{#ADVSNMPINDEX2}": "1",
                "{#ADVSNMPVALUE}":"Vlan1"
                }       ,
                {
                "{#ADVSNMPINDEX1}": "",
                "{#ADVSNMPINDEX2}": "10101",
                "{#ADVSNMPVALUE}":"GigabitEthernet0/1"
                }       ,
                {
                "{#ADVSNMPINDEX1}": "",
                "{#ADVSNMPINDEX2}": "10102",
                "{#ADVSNMPVALUE}":"GigabitEthernet0/2"
                }       ,
                {
                "{#ADVSNMPINDEX1}": "",
                "{#ADVSNMPINDEX2}": "10103",
                "{#ADVSNMPVALUE}":"GigabitEthernet0/3"
                }       ,
                {
                "{#ADVSNMPINDEX1}": "",
                "{#ADVSNMPINDEX2}": "10104",
                "{#ADVSNMPVALUE}":"GigabitEthernet0/4"
                }       ,
... 
        ]
}
```
